### PR TITLE
Remove base64 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "mocha": "^2.1.0"
   },
   "dependencies": {
-    "base64": "^2.1.0",
     "coffee-script": "^1.8.0",
     "github": "^0.2.3",
     "promise": "^6.1.0",

--- a/src/githubtools.coffee
+++ b/src/githubtools.coffee
@@ -1,4 +1,3 @@
-Base64 = require 'base64'
 GitHubApi = require 'github'
 Promise = require 'promise'
 
@@ -21,7 +20,7 @@ class @GitHubReqFileParser
     @githubGetContent(params).then(
       (res) ->
         current_packages = []
-        for lib in Base64.decode(res.content).split('\n')
+        for lib in (new Buffer(res.content, 'base64')).toString().split('\n')
           if lib != '' and not lib.match('^-r') and not lib.match('^#')
             [name, current_version] = lib.split('==')
             current_packages.push {name: name, current_version: current_version}


### PR DESCRIPTION
https://travis-ci.org/kanmu/kanmukun/builds/69616113#L310-L393
- base64 まわりでビルドに失敗するっぽい
- base64 は Buffer で代替できるので dependencies から除去してみた
- (test は Cakefile がなかったり pip package が決め打ちだったりしたのでスルー…)
  - 代わりに `node_modules/.bin/hubot` で動作確認済
